### PR TITLE
Reset failed units wanted-by session target

### DIFF
--- a/src/session.sh
+++ b/src/session.sh
@@ -91,6 +91,9 @@ if hash dbus-update-activation-environment 2>/dev/null; then
     dbus-update-activation-environment --systemd ${VARIABLES:- --all}
 fi
 
+# reset failed state of all user units
+systemctl --user reset-failed
+
 # shellcheck disable=SC2086
 systemctl --user import-environment $VARIABLES
 systemctl --user start "$SESSION_TARGET"


### PR DESCRIPTION
Sometimes services can fail. Failed services will not be started by
systemd when they are WantedBy=SESSION_TARGET. To start previously
failed services we can just reset their failed state before starting
our session target. Just make sure that we are only touching services
that our session target will start.

---
This is based on the snippet from https://people.debian.org/~mpitt/systemd.conf-2016-graphical-session.pdf Slide 14
I needed to change it a little, as we have mutliple target units (`wayland-session.target` and `sway-session.target`) and the code from Martin Pitt only works when services have defined `PartOf=graphical-session.target`.