### PR TITLE
feat: define template sway-session@$WAYLAND_DISPLAY.target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,9 @@ exec_dir = join_paths(
 conf_data = configuration_data()
 conf_data.set('execdir', exec_dir)
 
-install_data('sway-session.target',
+install_data(
+  'sway-session.target',
+  'sway-session@.target',
   install_dir: systemd.get_pkgconfig_variable('systemduserunitdir')
 )
 

--- a/src/session.sh
+++ b/src/session.sh
@@ -40,7 +40,7 @@
 export XDG_CURRENT_DESKTOP=sway
 export XDG_SESSION_TYPE=wayland
 VARIABLES="DISPLAY I3SOCK SWAYSOCK WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE"
-SESSION_TARGET="sway-session.target"
+SESSION_TARGET="sway-session@$WAYLAND_DISPLAY.target"
 WITH_CLEANUP=""
 
 print_usage() {
@@ -84,7 +84,7 @@ done
 
 # check if another session is already active:
 # either the target is active or the DISPLAY variables are set in systemd
-if systemctl --user -q is-active "$SESSION_TARGET" ||
+if systemctl --user -q is-active "${SESSION_TARGET%%@*}.target" ||
     (test -n "$WITH_CLEANUP" && test -n "$VARIABLES" &&
         systemctl --user show-environment | grep -qE '^(WAYLAND_)?DISPLAY=')
 then

--- a/srpm/sway-systemd.spec.rpkg
+++ b/srpm/sway-systemd.spec.rpkg
@@ -62,6 +62,7 @@ This includes several areas of integration:
 %dir %{_libexecdir}/%{srcname}
 %{_libexecdir}/%{srcname}/session.sh
 %{_userunitdir}/sway-session.target
+%{_userunitdir}/sway-session@.target
 
 %if %{with cgroups}
 %config(noreplace) %{_sysconfdir}/sway/config.d/10-systemd-cgroups.conf

--- a/sway-session.target
+++ b/sway-session.target
@@ -1,6 +1,8 @@
 [Unit]
-Description=sway session
+Description=Sway session
 Documentation=man:systemd.special(7)
+RefuseManualStart=yes
+StopWhenUnneeded=yes
 BindsTo=graphical-session.target
 Wants=graphical-session-pre.target
 After=graphical-session-pre.target

--- a/sway-session@.target
+++ b/sway-session@.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Sway session on %i
+Documentation=man:systemd.special(7)
+BindsTo=sway-session.target
+RefuseManualStart=no


### PR DESCRIPTION
The target can be used to activate template units that require the specifier to be a wayland display name.

Example usage with foot socket activation PR[1]:
```
$ systemctl --user add-wants sway-session@.target foot-server@.socket
```
or even better - with a proper termination when the session exits
```
$ systemctl --user edit foot-server@.socket
[Unit]
PartOf=sway-session@.target
After=sway-session@.target

[Install]
WantedBy=sway-session@.target

$ systemctl --user enable foot-server@.socket
```





Fixes #13

[1]: https://codeberg.org/dnkl/foot/pulls/890