### PR TITLE
Feature: Start passing through SSH_AUTH_SOCK to the systemd user units

### DIFF
--- a/config.d/10-systemd-session.conf.in
+++ b/config.d/10-systemd-session.conf.in
@@ -8,6 +8,7 @@
 #    - DISPLAY - for X11 applications that are started as user session services
 #    - WAYLAND_DISPLAY - similarly, this is needed for wayland-native services
 #    - I3SOCK/SWAYSOCK - allow services to talk with sway using i3 IPC protocol
+#    - SSH_AUTH_SOCK - connect to an ssh-agent instance such gnome-keyring-daemon
 #
 # 2. `xdg-desktop-portal` requires XDG_CURRENT_DESKTOP to be set in order to
 #    select the right implementation for screenshot and screencast portals.

--- a/src/session.sh
+++ b/src/session.sh
@@ -10,6 +10,7 @@
 #    - DISPLAY - for X11 applications that are started as user session services
 #    - WAYLAND_DISPLAY - similarly, this is needed for wayland-native services
 #    - I3SOCK/SWAYSOCK - allow services to talk with sway using i3 IPC protocol
+#    - SSH_AUTH_SOCK - connect to an ssh-agent instance such gnome-keyring-daemon
 #
 # 2. `xdg-desktop-portal` requires XDG_CURRENT_DESKTOP to be set in order to
 #    select the right implementation for screenshot and screencast portals.
@@ -37,7 +38,7 @@
 #  - https://systemd.io/DESKTOP_ENVIRONMENTS/
 #
 export XDG_CURRENT_DESKTOP=sway
-VARIABLES="DISPLAY I3SOCK SWAYSOCK WAYLAND_DISPLAY XDG_CURRENT_DESKTOP"
+VARIABLES="DISPLAY I3SOCK SWAYSOCK WAYLAND_DISPLAY XDG_CURRENT_DESKTOP SSH_AUTH_SOCK"
 SESSION_TARGET="sway-session.target"
 
 # DBus activation environment is independent from systemd. While most of


### PR DESCRIPTION
An SSH agent like gnome-keyring-daemon may started before Sway starts
and export SSH_AUTH_SOCK to Sway to pass through to child processes so
that both graphical and console apps can access the agent.

Now, connecting to the SSH agent could break when using foot's systemd
socket activation. This happens because systemd services are run
in a "clean" environment that only contains environment variables that
are explicitly set there. It doesn't automatically inherit environment variables set
in the login environment.

https://codeberg.org/dnkl/foot/pulls/890

Note that while setting SSH_AUTH_SOCK solves a common problem with a
systemd-activated console service, there may be other varibles set in the Sway environment that
users expect to appear within a systemd socket-activated terminal
service.

Those will still need to be passed through using existing `--add-env` flag to session.sh
