### PR TITLE
fix(meson): Build & install configs for autostart and locale1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,11 +21,13 @@ if not get_option('cgroups').disabled()
 endif
 
 if get_option('autostart')
+  configs += 'config.d/95-xdg-desktop-autostart.conf.in'
   scripts += 'src/wait-sni-ready'
   unit_files += 'sway-xdg-autostart.target'
 endif
 
 if get_option('locale1')
+  configs += 'config.d/95-system-keyboard-config.conf.in'
   scripts += 'src/locale1-xkb-config'
 endif
 


### PR DESCRIPTION
When building with -Dlocale1=true and/or -Dautostart=true the config.d/95-* files are not installed nor built. This patch fixes that.