### PR TITLE
Allow specifying the configuration files to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ systemd interface, translates it into a Sway configuration and applies to all de
 The main motivation for this component was an ability to apply system-wide keyboard mappings configured in the OS installer
 to a greetd or SDDM greeter running with Sway as a display server.
 
-The component is not enabled by default, use `-Dlocale1=true` to install the helper script and check
+The component is not enabled by default, use `-Dautoload-configs=locale1,...`
+to install the configuration file to Sway's default config drop-in directory
 [`95-system-keyboard-config.conf`](./config.d/95-system-keyboard-config.conf.in) for necessary configuration.
 
 ### XDG Desktop autostart target
@@ -73,8 +74,9 @@ The recommended way to start it is a `Wants=xdg-desktop-autostart.target` in a D
 Most notably, there's a race between the autostarted applications and the panel with StatusNotifierHost implementation.
 SNI specification is very clear on that point; if the `StatusNotifierWatcher` is unavailable or `IsStatusNotifierHostRegistered` is not set, the application should fallback to XEmbed tray. There are even known implementations that follow this requirement (Qt...) and will fail to create a status icon if started before the panel.
 
-The component is not enabled by default, use `-Dautostart=true` to install the target and the helper script
-and check [`95-xdg-desktop-autostart.conf`](./config.d/95-xdg-desktop-autostart.conf.in) for necessary configuration.
+The component is not enabled by default, use `-Dautoload-configs=autostart,...`
+to install the configuration file to Sway's default config drop-in directory
+or check [`95-xdg-desktop-autostart.conf`](./config.d/95-xdg-desktop-autostart.conf.in) for necessary configuration.
 
 ## Installation
 
@@ -100,7 +102,8 @@ meson build
 sudo ninja -C build install
 ```
 
-Only the session part is installed by default. Pass `-Dcgroups=enabled` to the `meson build` command to install cgroups assignment script as well.
+All the components will be installed, but only the session part will be enabled by default.\
+Pass `-Dautoload-configs=autostart,cgroups,locale1` or `-Dautoload-configs=all` to the `meson build` command to enable the remaining components.
 
 The command will install configuration files from [`config.d`](./config.d/) to the `/etc/sway/config.d/` directory which is included from the default sway config. If you are using custom sway configuration file and already removed the `include /etc/sway/config.d/*` line you may need to edit your config and include the installed files.
 

--- a/meson.build
+++ b/meson.build
@@ -3,39 +3,30 @@ project('sway-systemd', [],
   license: 'MIT',
 )
 
-configs = [
-  'config.d/10-systemd-session.conf.in',
-]
+enabled = get_option('autoload-configs')
+configs = {
+  'config.d/10-systemd-session.conf.in':        true,
+  'config.d/10-systemd-cgroups.conf.in':        enabled.contains('all') or enabled.contains('cgroups'),
+  'config.d/95-system-keyboard-config.conf.in': enabled.contains('all') or enabled.contains('locale1'),
+  'config.d/95-xdg-desktop-autostart.conf.in':  enabled.contains('all') or enabled.contains('autostart'),
+}
 
 scripts = [
   'src/session.sh',
+  'src/assign-cgroups.py',
+  'src/wait-sni-ready',
+  'src/locale1-xkb-config',
 ]
 
 unit_files = [
   'sway-session.target',
+  'sway-xdg-autostart.target',
 ]
 
-if not get_option('cgroups').disabled()
-  configs += 'config.d/10-systemd-cgroups.conf.in'
-  scripts += 'src/assign-cgroups.py'
-endif
-
-if get_option('autostart')
-  scripts += 'src/wait-sni-ready'
-  unit_files += 'sway-xdg-autostart.target'
-endif
-
-if get_option('locale1')
-  scripts += 'src/locale1-xkb-config'
-endif
-
 systemd = dependency('systemd')
-conf_dir = join_paths(get_option('sysconfdir'), 'sway', 'config.d')
-exec_dir = join_paths(
-  get_option('prefix'),
-  get_option('libexecdir'),
-  meson.project_name(),
-)
+conf_dir = get_option('sysconfdir') / 'sway' / 'config.d'
+exec_dir = get_option('libexecdir') / meson.project_name()
+data_dir = get_option('datadir') / meson.project_name()
 
 install_data(
   scripts,
@@ -51,11 +42,11 @@ install_data(
 conf_data = configuration_data()
 conf_data.set('execdir', exec_dir)
 
-foreach config : configs
+foreach config, enabled : configs
   configure_file(
     configuration: conf_data,
     input: config,
     output: '@BASENAME@',
-    install_dir: conf_dir,
+    install_dir: enabled ? conf_dir : data_dir,
   )
 endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,3 @@
-# TODO: convert to boolean
-option('cgroups', type: 'feature', value: 'disabled',
-       description: 'Install script for assigning cgroups to applications')
-option('autostart', type: 'boolean', value: false,
-       description: 'Install targets and scripts for systemd XDG desktop autostart support')
-option('locale1', type: 'boolean', value: false,
-       description: 'Install script for applying org.freedesktop.locale1 input configuration to Sway')
+option('autoload-configs', type: 'array',
+       choices: ['all', 'autostart', 'cgroups', 'locale1'], value: [],
+       description: 'Install configuration for selected components into a system-wide Sway include directory (/etc/sway/config.d)')

--- a/srpm/sway-systemd.spec.rpkg
+++ b/srpm/sway-systemd.spec.rpkg
@@ -36,7 +36,7 @@ and scripts required for running Sway in a systemd environment.
 This includes several areas of integration:
  - Propagate required variables to the systemd user session environment.
  - Define sway-session.target for starting user services.
-%{?with_cgroups: - Place GUI applications into a systemd scopes for systemd-oomd compatibility.}
+ - Place GUI applications into a systemd scopes for systemd-oomd compatibility.
 
 %prep
 {{{ git_setup_macro path=$(git rev-parse --show-toplevel) }}}
@@ -44,9 +44,7 @@ This includes several areas of integration:
 
 %build
 %meson \
-    -Dautostart=true \
-    -Dcgroups=enabled \
-    -Dlocale1=true
+    -Dautoload-configs='cgroups'
 %meson_build
 
 
@@ -59,6 +57,7 @@ This includes several areas of integration:
 %doc README.md
 %config(noreplace) %{_sysconfdir}/sway/config.d/10-systemd-session.conf
 %config(noreplace) %{_sysconfdir}/sway/config.d/10-systemd-cgroups.conf
+%{_datadir}/%{srcname}/*.conf
 %dir %{_libexecdir}/%{srcname}
 %{_libexecdir}/%{srcname}/assign-cgroups.py
 %{_libexecdir}/%{srcname}/locale1-xkb-config


### PR DESCRIPTION
All the scripts and targets are now installed unconditionally.

You can choose the configuration snippets to be installed into the default autoload directory for Sway (`/etc/sway/config.d`) and sourced from the default configuration with `-Dautoload-configs` option.
Snippets for the remaining components are installed to the application data directory (`/usr/share/sway-systemd`) and can be included from the user's config directly.

BREAKING: please, check meson_options.txt for the new set of available options.
BREAKING: having all the components always installed may introduce additional dependencies. If you are doing the distribution package update, please check that the dependencies are correct and available or remove unwanted files.

Fixes #22
Closes #20