### PR TITLE
Change session cleanup mechanism

### DIFF
--- a/src/session.sh
+++ b/src/session.sh
@@ -43,7 +43,7 @@ VARIABLES="DESKTOP_SESSION XDG_CURRENT_DESKTOP XDG_SESSION_DESKTOP XDG_SESSION_T
 VARIABLES="${VARIABLES} DISPLAY I3SOCK SWAYSOCK WAYLAND_DISPLAY"
 SESSION_TARGET="sway-session.target"
 SESSION_SHUTDOWN_TARGET="sway-session-shutdown.target"
-WITH_CLEANUP=1
+ENV_FILE="$XDG_RUNTIME_DIR/$SESSION_TARGET.env"
 
 print_usage() {
     cat <<EOH
@@ -52,8 +52,19 @@ Usage:
   --add-env NAME, -E NAME
                     Add a variable name to the subset of environment passed
                     to the user session. Can be specified multiple times.
-  --no-cleanup      Skip cleanup code at compositor exit.
+  --exit            Stop sway session and exit sway.
 EOH
+}
+
+session_cleanup () {
+    # stop the session target and unset the variables
+    systemctl --user start --job-mode=replace-irreversibly "$SESSION_SHUTDOWN_TARGET"
+    if [ -f "$ENV_FILE" ]; then
+        # shellcheck disable=SC2086
+        xargs -a "$ENV_FILE" systemctl --user unset-environment
+        rm "$ENV_FILE"
+    fi
+    swaymsg exit
 }
 
 while [ $# -gt 0 ]; do
@@ -72,10 +83,9 @@ while [ $# -gt 0 ]; do
     --add-env | -E)
         shift
         VARIABLES="${VARIABLES} ${1}" ;;
-    --with-cleanup)
-        ;; # ignore (enabled by default)
-    --no-cleanup)
-        unset WITH_CLEANUP ;;
+    --exit)
+        session_cleanup
+        exit ;;
     -*)
         echo "Unexpected option: $1" 1>&2
         print_usage
@@ -111,26 +121,4 @@ systemctl --user reset-failed
 # shellcheck disable=SC2086
 systemctl --user import-environment $VARIABLES
 systemctl --user start "$SESSION_TARGET"
-
-# Optionally, wait until the compositor exits and cleanup variables and services.
-if [ -z "$WITH_CLEANUP" ] ||
-    [ -z "$SWAYSOCK" ] ||
-    ! hash swaymsg 2>/dev/null
-then
-    exit 0;
-fi
-
-# declare cleanup handler and run it on script termination via kill or Ctrl-C
-session_cleanup () {
-    # stop the session target and unset the variables
-    systemctl --user start --job-mode=replace-irreversibly "$SESSION_SHUTDOWN_TARGET"
-    if [ -n "$VARIABLES" ]; then
-        # shellcheck disable=SC2086
-        systemctl --user unset-environment $VARIABLES
-    fi
-}
-trap session_cleanup INT TERM
-# wait until the compositor exits
-swaymsg -t subscribe '["shutdown"]'
-# run cleanup handler on normal exit
-session_cleanup
+echo "$VARIABLES" > "$ENV_FILE"

--- a/src/session.sh
+++ b/src/session.sh
@@ -64,7 +64,6 @@ session_cleanup () {
         xargs -a "$ENV_FILE" systemctl --user unset-environment
         rm "$ENV_FILE"
     fi
-    swaymsg exit
 }
 
 while [ $# -gt 0 ]; do
@@ -85,6 +84,7 @@ while [ $# -gt 0 ]; do
         VARIABLES="${VARIABLES} ${1}" ;;
     --exit)
         session_cleanup
+        swaymsg exit
         exit ;;
     -*)
         echo "Unexpected option: $1" 1>&2


### PR DESCRIPTION
I don't feel comfortable when there is a whole bash process hanging out there and waiting for the sway to exit. I think there is a better approach to this. Similar to good old pid files, we can store env variables in the user's runtime dir and use it to clean up the session.
The only significant change is that now we must exit sway by calling `session.sh --exit`.
Currently the config command looks like this: `exec /usr/lib/sway-systemd/session.sh --exit`
In order to make it look better, I suggest moving `session.sh` to `/usr/bin/` and renaming it to `sway-session` so that the final command looks like this: `exec sway-session --exit`
WDYT?