### PR TITLE
Remove variant before setting new localed layouts

### DIFF
--- a/src/locale1-xkb-config
+++ b/src/locale1-xkb-config
@@ -95,10 +95,11 @@ class Locale1Client:
         LOG.info("xkb(%s): layout '%s' model '%s', variant '%s' options '%s'",
                  self._device, self.layout, self.model, self.variant,
                  self.options)
-        cmd = {
+        cmd = [f"input {self._device} xkb_variant ''"]
+        cmd.extend([
             f"input {self._device} xkb_{name} '{self.__dict__[name]}'"
             for name in PROPERTIES.values()
-        }
+        ])
         replies = await self._conn.command(', '.join(cmd))
         for cmd, reply in zip(cmd, replies):
             if reply.error is not None:


### PR DESCRIPTION
If Sway has multiple layouts with some variants the script might fail. Reason is that the existing variants will stay for new layouts which can easily get into unsupported variant.

For example, having this set:
xkb_layout: us,cz
xkb_variant: ,qwerty

works until you set:
xkb_layout: cz,us
xkb_variant: qwerty,

The issue is that layout is set first and raise error:

Couldn't process include statement for 'us(qwerty)'

Fix this by cleaning up variants before setting layouts.